### PR TITLE
[Day11-12] Webtoon Weekday Tab 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import { config } from "@gluestack-ui/config"
-import { GluestackUIProvider, StatusBar, SafeAreaView } from "@gluestack-ui/themed"
+import { GluestackUIProvider, StatusBar, SafeAreaView, View } from "@gluestack-ui/themed"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createStackNavigator } from '@react-navigation/stack';
 import { NavigationContainer } from "@react-navigation/native";
@@ -11,6 +11,7 @@ import DetailHeader from "./components/Header/DetailHeader";
 import Ionicons from '@expo/vector-icons/Ionicons';
 import WebtoonDetailScreen from "./screens/WebtoonDetailScreen";
 import MyScreen from "./screens/MyScreen";
+import WebtoonScreen from "./screens/WebtoonScreen";
 
 const queryClient = new QueryClient();
 const Stack = createStackNavigator<ScreensParams>(); // 라우트 타입 지정(필수)
@@ -27,7 +28,7 @@ function Tabs() {
     >
       <Tab.Screen 
         name='Home'
-        component={HomeScreen}
+        component={WebtoonScreen}
         options={{
           tabBarIcon: ({ color, size })=> (
             <Ionicons name='list' size={size} color={color} />
@@ -52,7 +53,7 @@ export default function App() {
   <QueryClientProvider client={queryClient}>
    <GluestackUIProvider config={config}>
     <StatusBar barStyle='light-content' />
-      <SafeAreaView flex={1} backgroundColor='$backgroundDark950'>
+      <View flex={1} backgroundColor='$backgroundDark950'>
         <NavigationContainer>
           <Stack.Navigator screenOptions={{ headerShown: false }}>
             <Stack.Screen name='Main' component={Tabs} />
@@ -65,7 +66,8 @@ export default function App() {
             }}/>
           </Stack.Navigator>
         </NavigationContainer>
-      </SafeAreaView>
+        </View>
+      <SafeAreaView bg='$backgroundDark950' />
    </GluestackUIProvider>
   </QueryClientProvider>
   )

--- a/App.tsx
+++ b/App.tsx
@@ -52,7 +52,7 @@ export default function App() {
   return (
   <QueryClientProvider client={queryClient}>
    <GluestackUIProvider config={config}>
-    <StatusBar barStyle='light-content' />
+    <StatusBar barStyle='dark-content' />
       <View flex={1} backgroundColor='$backgroundDark950'>
         <NavigationContainer>
           <Stack.Navigator screenOptions={{ headerShown: false }}>

--- a/components/Carousel/CarouselCard.tsx
+++ b/components/Carousel/CarouselCard.tsx
@@ -1,8 +1,9 @@
 import  React  from 'react'
-import { Box } from "@gluestack-ui/themed"
+import { Box, VStack } from "@gluestack-ui/themed"
 import { TripleWebtoon  } from "../../types"
 import { Image } from 'expo-image';
 import convertUrl from '../../utils/convertUrl';
+import { Text } from '@gluestack-ui/themed';
 
 interface LargeCardProps {
     webtoon: TripleWebtoon;
@@ -41,7 +42,12 @@ export default function CarouselCard({ webtoon }: LargeCardProps) {
                 }}>
             </Image>
         </Box>
+        <Box pl={20} pb={20}>
+            <Text size='xl' bold={true} bg='$backgroundDark900' alignSelf='flex-start' color='white'>{webtoon.title}</Text>
+            <Text size='md'>{webtoon.displayAuthor}</Text>
+        </Box>
    </Box>
+   
   );
 }
 

--- a/components/Carousel/CarouselCard.tsx
+++ b/components/Carousel/CarouselCard.tsx
@@ -1,0 +1,47 @@
+import  React  from 'react'
+import { Box } from "@gluestack-ui/themed"
+import { TripleWebtoon  } from "../../types"
+import { Image } from 'expo-image';
+import convertUrl from '../../utils/convertUrl';
+
+interface LargeCardProps {
+    webtoon: TripleWebtoon;
+}
+
+export default function CarouselCard({ webtoon }: LargeCardProps) {
+  return (
+    <Box w='$full' h='$full' justifyContent='flex-end'>
+        <Box w='$full' h='$full' position='absolute' bg={`#${webtoon.bgColor}`} > 
+            <Image 
+                contentFit='contain'
+                source={{uri: convertUrl(webtoon.bgImage)}} // onError={(error) => console.log(error)}
+                style={{
+                    width: '100%',
+                    height: '100%'
+                }}>
+            </Image>
+        </Box>
+        <Box w='$full' h='$full' position='absolute'>
+            <Image 
+                contentFit='contain'
+                source={{uri: convertUrl(webtoon.backImage)}} 
+                style={{
+                    width: '100%',
+                    height: '100%'
+                }}>
+            </Image>
+        </Box>
+        <Box w='$full' h='$full' position='absolute'>
+            <Image 
+                contentFit='contain'
+                source={{uri: convertUrl(webtoon.frontImage)}} 
+                style={{
+                    width: '100%',
+                    height: '100%'
+                }}>
+            </Image>
+        </Box>
+   </Box>
+  );
+}
+

--- a/components/Carousel/WebtoonCarousel.tsx
+++ b/components/Carousel/WebtoonCarousel.tsx
@@ -1,0 +1,32 @@
+import  React  from 'react'
+import { useQuery } from "@tanstack/react-query"
+import Swiper from "react-native-swiper"
+import { TripleWebtoonResponse, WebtoonResponse } from '../../types'
+import CarouselCard from '../Carousel/CarouselCard'
+import { Center } from '@gluestack-ui/themed'
+
+const fetchWebtoons = async () => { // 비동기 함수, promise 반환, async 익명함수
+    const response = await fetch('https://comic.naver.com/api/tripleRecommend?week=undefined&tag=true&sortByUpdate=true');
+    return response.json();
+}
+
+export default function WebtoonCarousel() {
+    const { data } = useQuery<TripleWebtoonResponse> ({ // Webtoon 배열
+        queryKey: ['TripleRecommend'], // 쿼리 식별하는 고유한 키
+        queryFn: fetchWebtoons, // 쿼리를 실행하는 비동기 함수
+    });
+
+    // console.log(data);
+    const webtoons = data?.itemList || [];
+
+  return (
+    <Center flex={1} w='$full' h='$full'>
+      { webtoons.length > 0 && (<Swiper showsButtons={false}>
+        {webtoons?.map((webtoon) => ( 
+          <CarouselCard  webtoon={webtoon} />
+      ))}
+      </Swiper>
+      )}
+    </Center>
+    );
+}

--- a/components/Header/MySwiper.tsx
+++ b/components/Header/MySwiper.tsx
@@ -10,13 +10,15 @@ const fetchWebtoons = async () => { // 비동기 함수, promise 반환, async �
 }
 
 export default function MySwiper() {
-    const { data } = useQuery<WebtoonResponse> ({
+    const { data } = useQuery<WebtoonResponse> ({ // Webtoon 배열
         queryKey: ['https://korea-webtoon-api.herokuapp.com'], // 쿼리 식별하는 고유한 키
         queryFn: fetchWebtoons, // 쿼리를 실행하는 비동기 함수
     });
 
+  console.log(data);
+
   return (
-    <Swiper showsButtons={false}>
+    <Swiper showsButtons={false} removeClippedSubviews={true} >
         { data ? data.webtoons.map((webtoon) => ( // 배열 내의 모든 요소 각각 호출
         <LargeCard key={webtoon.webtoonId} webtoon={webtoon} />
         )): []}

--- a/components/WeekDay/WeekDayCard.tsx
+++ b/components/WeekDay/WeekDayCard.tsx
@@ -1,0 +1,58 @@
+import { Center, HStack, VStack } from "@gluestack-ui/themed";
+import { WeekDayWebtoon } from "../../types";
+import { Image } from "expo-image";
+import convertUrl from "../../utils/convertUrl";
+import { Dimensions } from "react-native";
+import { Text } from "@gluestack-ui/themed";
+import Icon from 'react-native-vector-icons/Ionicons';
+
+interface WeekDayCardProps {
+    webtoon: WeekDayWebtoon;
+}
+
+const width = Dimensions.get('window').width;
+
+export default function WeekDayCard({ webtoon }: WeekDayCardProps) {
+  return (
+    <VStack w={width / 3.2} gap={2} >
+      <Image 
+        transition={500}
+        source={{uri: convertUrl(webtoon.thumbnailUrl)}} // onError={(error) => console.log(error)}
+        style={{ width: '100%', height: (width / 3) * 1.3, borderRadius: 3}} >
+      </Image>
+      <VStack position='absolute' w={40} h={40} p={4} gap={1}>
+        {webtoon.new && (
+          <Center w={20} h={20} bg='$green500' borderRadius='$full'>
+            <Text size='2xs' bold={true} color='$black'>신작</Text>
+          </Center>
+        )}
+        {webtoon.bm && (
+          <Center w={20} h={20}  borderRadius='$full' pl={0.2} paddingTop={0.1} style={{backgroundColor: 'rgba(0,0,0,0.7)' }} >
+            <Icon size={20} name='timer-outline' color='#22c55e'></Icon>
+          </Center>
+        )}
+        {webtoon.adult && (
+          <Center w={20} h={20} >
+            <Icon size={20} name='shield' color='#fb923c'></Icon>
+            <Icon size={9} name='person' color='white' position='absolute' paddingBottom={1}></Icon>
+          </Center>
+        )}
+      </VStack>
+      <VStack p={2} paddingLeft={2} gap={-3}>
+        <Text size='xs' color='$backgroundLight100' bold={true} isTruncated={true}>{webtoon.titleName}</Text>
+        <HStack maxWidth={(width / 3.2) - 35} alignItems='center' gap={2}>
+            <Text size='2xs' color='gray' isTruncated={true}>
+              {webtoon.author}
+            </Text>
+            <HStack alignItems='center' gap={1}>
+              <Icon size={8} name='star' color='gray'></Icon>
+              <Text w={23} size='2xs' color='gray'>
+                {webtoon.starScore.toFixed(2)}
+              </Text>
+            </HStack>
+        </HStack>
+      </VStack>
+    </VStack>
+    
+  );
+}

--- a/components/WeekDay/WeekDayList.tsx
+++ b/components/WeekDay/WeekDayList.tsx
@@ -1,0 +1,35 @@
+import  React  from 'react'
+import { Center, HStack } from "@gluestack-ui/themed"
+import { WeekDayWebtoonResponse } from '../../types';
+import { useQuery } from '@tanstack/react-query';
+import WeekDayCard from './WeekDayCard';
+import { ScrollView } from '@gluestack-ui/themed';
+
+const fetchWebtoons = async (type: string) => { // 비동기 함수, promise 반환, async 익명함수
+    const response = await fetch(`https://comic.naver.com/api/webtoon/titlelist/weekday?week=${type}&order=user`);
+    return response.json();
+}
+
+interface WeekDayListProps {
+    type: string
+}
+
+export default function WeekDayList({type}: WeekDayListProps) {
+    const { data } = useQuery<WeekDayWebtoonResponse> ({ // Webtoon 배열
+        queryKey: ['weekday', type], // 쿼리 식별하는 고유한 키, 따로따로 API 호출
+        queryFn: () => fetchWebtoons(type), // 쿼리를 실행하는 비동기 함수
+    });
+
+    return (
+        <ScrollView>
+            <Center width='100%' height='100%'>
+                <HStack flexWrap='wrap' gap={5} top={3} left={5}>
+                    {data?.titleList.slice(0, 15).map((webtoon) => (
+                        <WeekDayCard key={webtoon.titleId} webtoon={webtoon}/>
+                    ))}
+                </HStack>
+            </Center>
+        </ScrollView>
+    );
+}
+

--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,5 @@
 export const DayArray = [
-    {key: 'daily', title: '매일'},
+    {key: 'dailyPlus', title: '매일'},
     {key: 'mon', title: '월'},
     {key: 'tue', title: '화'},
     {key: 'wed', title: '수'},

--- a/constants.ts
+++ b/constants.ts
@@ -1,0 +1,10 @@
+export const DayArray = [
+    {key: 'daily', title: '매일'},
+    {key: 'mon', title: '월'},
+    {key: 'tue', title: '화'},
+    {key: 'wed', title: '수'},
+    {key: 'thu', title: '목'},
+    {key: 'fri', title: '금'},
+    {key: 'sat', title: '토'},
+    {key: 'sun', title: '일'},
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,10 @@
         "react": "18.2.0",
         "react-native": "0.73.4",
         "react-native-gesture-handler": "~2.14.0",
+        "react-native-pager-view": "6.2.3",
         "react-native-svg": "14.1.0",
-        "react-native-swiper": "^1.6.0"
+        "react-native-swiper": "^1.6.0",
+        "react-native-tab-view": "^3.5.2"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -14155,6 +14157,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-pager-view": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.2.3.tgz",
+      "integrity": "sha512-dqVpXWFtPNfD3D2QQQr8BP+ullS5MhjRJuF8Z/qml4QTILcrWaW8F5iAxKkQR3Jl0ikcEryG/+SQlNcwlo0Ggg==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.9.0.tgz",
@@ -14198,6 +14209,19 @@
       "integrity": "sha512-OnkTTZi+9uZUgy0uz1I9oYDhCU3z36lZn+LFsk9FXPRelxb/KeABzvPs3r3SrHWy1aA67KGtSFj0xNK2QD0NJQ==",
       "dependencies": {
         "prop-types": "^15.5.10"
+      }
+    },
+    "node_modules/react-native-tab-view": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-3.5.2.tgz",
+      "integrity": "sha512-nE5WqjbeEPsWQx4mtz81QGVvgHRhujTNIIZiMCx3Bj6CBFDafbk7XZp9ocmtzXUQaZ4bhtVS43R4FIiR4LboJw==",
+      "dependencies": {
+        "use-latest-callback": "^0.1.5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-pager-view": "*"
       }
     },
     "node_modules/react-native-web": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-query": "^5.18.1",
     "expo": "^50.0.8",
     "expo-dev-client": "~3.3.9",
+    "expo-image": "~1.10.6",
     "expo-status-bar": "~1.11.1",
     "expo-updates": "~0.24.11",
     "react": "18.2.0",
@@ -26,7 +27,8 @@
     "react-native-gesture-handler": "~2.14.0",
     "react-native-svg": "14.1.0",
     "react-native-swiper": "^1.6.0",
-    "expo-image": "~1.10.6"
+    "react-native-tab-view": "^3.5.2",
+    "react-native-pager-view": "6.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/screens/WebtoonScreen.tsx
+++ b/screens/WebtoonScreen.tsx
@@ -1,0 +1,36 @@
+import { NavigationProp, useNavigation } from "@react-navigation/native"
+import { ScreensParams } from "../types"
+import { Center, Text, VStack } from "@gluestack-ui/themed";
+import WebtoonCarousel from "../components/Carousel/WebtoonCarousel";
+import { TabBar, TabView } from "react-native-tab-view";
+import { useState } from "react";
+import { DayArray } from "../constants";
+
+export default function WebtoonScreen() {   
+    const [index, setIndex] = useState(0);
+    
+    const navigation = useNavigation<NavigationProp<ScreensParams>>();
+    return (
+    <VStack w='$full' h='$full' bg='$backgroundDark950'>
+        <Center w='$full' h={250}>
+            <WebtoonCarousel />
+        </Center>
+
+        <TabView
+            navigationState={{ index, routes: DayArray }}
+            renderScene={() => (
+                <Center>
+                    <Text>Test</Text>
+                </Center>
+            )}
+            onIndexChange={setIndex}
+            renderTabBar= {(props) => <TabBar {...props} 
+                activeColor = '#16a34a'
+                indicatorStyle={{ backgroundColor: '#16a34a' }}
+                style={{ backgroundColor: '' }}
+            />
+        }
+        />
+    </VStack>
+    );
+  }

--- a/screens/WebtoonScreen.tsx
+++ b/screens/WebtoonScreen.tsx
@@ -1,10 +1,11 @@
 import { NavigationProp, useNavigation } from "@react-navigation/native"
 import { ScreensParams } from "../types"
-import { Center, Text, VStack } from "@gluestack-ui/themed";
+import { Center, VStack } from "@gluestack-ui/themed";
 import WebtoonCarousel from "../components/Carousel/WebtoonCarousel";
 import { TabBar, TabView } from "react-native-tab-view";
 import { useState } from "react";
 import { DayArray } from "../constants";
+import WeekDayList from "../components/WeekDay/WeekDayList";
 
 export default function WebtoonScreen() {   
     const [index, setIndex] = useState(0);
@@ -18,18 +19,17 @@ export default function WebtoonScreen() {
 
         <TabView
             navigationState={{ index, routes: DayArray }}
-            renderScene={() => (
-                <Center>
-                    <Text>Test</Text>
-                </Center>
-            )}
+            renderScene={(route) => {
+                return <WeekDayList type={route.route.key} />;
+            }}
             onIndexChange={setIndex}
             renderTabBar= {(props) => <TabBar {...props} 
                 activeColor = '#16a34a'
                 indicatorStyle={{ backgroundColor: '#16a34a' }}
-                style={{ backgroundColor: '' }}
+                style={{ backgroundColor: ''}}
+                labelStyle={{color: 'white', fontSize: 13, margin: 0, padding: 0, borderBottomColor: 'white', borderWidth: 1}}
             />
-        }
+            }
         />
     </VStack>
     );

--- a/types.ts
+++ b/types.ts
@@ -31,6 +31,7 @@ export interface WebtoonResponse {
 export interface Author {
     id: number,
     name: string
+    blogUrl? : string
 }
 
 export interface TripleWebtoon {
@@ -66,4 +67,29 @@ export interface TagList {
     tagName: string,
     urlPath: string,
     curationType: string
+}
+
+export interface WeekDayWebtoonResponse {
+    titleList: WeekDayWebtoon[]
+}
+
+export interface WeekDayWebtoon {
+    titleId: number,
+    titleName: string,
+    author: string,
+    writers: Author[],
+    painters: Author[],
+    novelOriginAuthors: Author[],
+    thumbnailUrl: string,
+    up: boolean,
+    rest: boolean,
+    bm: boolean,
+    adult: boolean,
+    starScore: number,
+    viewCount: number,
+    openToday: boolean,
+    potenUp: boolean,
+    bestChallengeLevelUp: boolean,
+    finish: boolean,
+    new: boolean
 }

--- a/types.ts
+++ b/types.ts
@@ -26,4 +26,44 @@ export type TabScreenParams = {
 
 export interface WebtoonResponse {
     webtoons: Webtoon[];
-  }
+}
+
+export interface Author {
+    id: number,
+    name: string
+}
+
+export interface TripleWebtoon {
+
+    titleId: number,
+    no: number,
+    title: string,
+    displayAuthor: string,
+    writers: Author[],
+    painters: Author[],
+    novelOriginAuthors: Author[],
+    summary: string,
+    starScore: number,
+    bgImage: string,
+    backImage: string,
+    frontImage: string,
+    bgColor: string,
+    bm: boolean,
+    adult: boolean,
+    rating: boolean,
+    up: boolean,
+    rest: boolean,
+    tagList: TagList[],
+    new: boolean
+}
+
+export interface TripleWebtoonResponse {
+    itemList: TripleWebtoon[];
+}
+
+export interface TagList {
+    id: number,
+    tagName: string,
+    urlPath: string,
+    curationType: string
+}

--- a/utils/convertUrl.ts
+++ b/utils/convertUrl.ts
@@ -1,0 +1,5 @@
+export default function convertUrl(url: string) {
+    return url
+      .replaceAll('/', '@')
+      .replace('https:@@', 'https://dotfeet-image-48ee370c0193.herokuapp.com/image/');
+}


### PR DESCRIPTION
네이버웹툰 웹사이트와 모바일 앱을 참고하여 요일 별 탭(Tab View)을 구현합니다. 각 웹툰마다 신작인지, bm(매일웹툰으로 추정)인지, 성인전용 콘텐츠인지를 알려주는 아이콘이 붙어있습니다. 

https://github.com/18hailey/myApp/assets/112684536/0e737c3f-9259-4b39-98a1-574c260a469c

+아이콘 배경 투명도 설정

