### PR TITLE
[Day13] Webtoon DetailScreen 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,14 +4,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createStackNavigator } from '@react-navigation/stack';
 import { NavigationContainer } from "@react-navigation/native";
 import { ScreensParams, TabScreenParams } from "./types";
-import HomeScreen from "./screens/HomeScreen"
-import SearchScreen from "./screens/SearchScreen";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
-import DetailHeader from "./components/Header/DetailHeader";
 import Ionicons from '@expo/vector-icons/Ionicons';
-import WebtoonDetailScreen from "./screens/WebtoonDetailScreen";
 import MyScreen from "./screens/MyScreen";
 import WebtoonScreen from "./screens/WebtoonScreen";
+import DetailScreen from "./screens/DetailScreen";
 
 const queryClient = new QueryClient();
 const Stack = createStackNavigator<ScreensParams>(); // 라우트 타입 지정(필수)
@@ -52,18 +49,15 @@ export default function App() {
   return (
   <QueryClientProvider client={queryClient}>
    <GluestackUIProvider config={config}>
-    <StatusBar barStyle='dark-content' />
+    <StatusBar barStyle='light-content' />
       <View flex={1} backgroundColor='$backgroundDark950'>
         <NavigationContainer>
           <Stack.Navigator screenOptions={{ headerShown: false }}>
             <Stack.Screen name='Main' component={Tabs} />
-            <Stack.Screen name='Search' component={SearchScreen} />
             <Stack.Screen
               name='Detail' 
-              component={WebtoonDetailScreen}
-              options={{
-                headerShown: true, header: () => <DetailHeader />
-            }}/>
+              component={DetailScreen}
+            />
           </Stack.Navigator>
         </NavigationContainer>
         </View>

--- a/components/Carousel/CarouselCard.tsx
+++ b/components/Carousel/CarouselCard.tsx
@@ -1,5 +1,5 @@
 import  React  from 'react'
-import { Box, VStack } from "@gluestack-ui/themed"
+import { Box } from "@gluestack-ui/themed"
 import { TripleWebtoon  } from "../../types"
 import { Image } from 'expo-image';
 import convertUrl from '../../utils/convertUrl';

--- a/components/Carousel/WebtoonCarousel.tsx
+++ b/components/Carousel/WebtoonCarousel.tsx
@@ -1,7 +1,7 @@
 import  React  from 'react'
 import { useQuery } from "@tanstack/react-query"
 import Swiper from "react-native-swiper"
-import { TripleWebtoonResponse, WebtoonResponse } from '../../types'
+import { TripleWebtoonResponse } from '../../types'
 import CarouselCard from '../Carousel/CarouselCard'
 import { Center } from '@gluestack-ui/themed'
 
@@ -23,7 +23,7 @@ export default function WebtoonCarousel() {
     <Center flex={1} w='$full' h='$full'>
       { webtoons.length > 0 && (<Swiper showsButtons={false}>
         {webtoons?.map((webtoon) => ( 
-          <CarouselCard  webtoon={webtoon} />
+          <CarouselCard key={webtoon.titleId} webtoon={webtoon} />
       ))}
       </Swiper>
       )}

--- a/components/Detail/DetailHeader.tsx
+++ b/components/Detail/DetailHeader.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@gluestack-ui/themed";
+import { Center, Text } from "@gluestack-ui/themed";
 import { HStack } from "@gluestack-ui/themed";
 import { WebtoonDetail } from "../../types";
 import { useQuery } from "@tanstack/react-query";
@@ -6,7 +6,7 @@ import { VStack } from "@gluestack-ui/themed";
 import { Box } from "@gluestack-ui/themed";
 import { Image } from "expo-image";
 import convertUrl from "../../utils/convertUrl";
-import { Dimensions } from "react-native";
+import { Dimensions, Pressable } from "react-native";
 import DetailInfo from "./DetailInfo";
 
 interface DetailHeaderProp {
@@ -32,22 +32,28 @@ export default function DetailHeader({titleId}: DetailHeaderProp) {
         return;
     }
 
-
     return (
     <VStack w='$full'>
         <Box position='absolute' bg='$blueGray500' w='$full' h={width / 2}></Box>
-        <Image 
-            contentFit='contain'
-            source={{uri: convertUrl(data.thumbnailUrl)}} // onError={(error) => console.log(error)}
-            style={{ width: width, height: width }}
-        ></Image>
+        <VStack justifyContent='flex-end' alignItems='center'>
+            <Image 
+                contentFit='contain'
+                source={{uri: convertUrl(data.thumbnailUrl)}} // onError={(error) => console.log(error)}
+                style={{ width: width, height: width }}
+            ></Image>
+            <Pressable onPress={() => alert('로그인 후 다시 시도해 주세요.')}>
+                <Center width={120} height={30} borderRadius={30} bg='$green600' bottom={50}>
+                    <Text color='$white' size='sm'>{`+ 관심 ${data.favoriteCount.toLocaleString('ko-KO')}`}</Text>
+                </Center>
+            </Pressable>
+        </VStack>
         <VStack px={15} py={10} gap={4}>
             <Text color='$backgroundLight100' size='xl'>{data.gfpAdCustomParam.titleName}</Text>
             <HStack>
                 <Text color='$backgroundLight100' size='sm'>{data.gfpAdCustomParam.displayAuthor}</Text>
                 <Text color='$secondary400' size='sm'>{`ㆍ${data.publishDescription}`}</Text>
             </HStack>
-            <DetailInfo synopsis={data.synopsis} />
+            <DetailInfo synopsis={data.synopsis} description={data.age.description}  />
         </VStack>
     </VStack>
     )

--- a/components/Detail/DetailHeader.tsx
+++ b/components/Detail/DetailHeader.tsx
@@ -25,9 +25,7 @@ export default function DetailHeader({titleId}: DetailHeaderProp) {
         queryKey: ['fetchArticleList', titleId], // 쿼리 식별하는 고유한 키
         queryFn: () => fetchArticleList(titleId), // 쿼리를 실행하는 비동기 함수
     });
-
-    // console.log(data?.titleName);
-
+ 
     if(!data) {
         return;
     }
@@ -42,7 +40,7 @@ export default function DetailHeader({titleId}: DetailHeaderProp) {
                 style={{ width: width, height: width }}
             ></Image>
             <Pressable onPress={() => alert('로그인 후 다시 시도해 주세요.')}>
-                <Center width={120} height={30} borderRadius={30} bg='$green600' bottom={50}>
+                <Center width={120} height={30} borderRadius={30} bg='$green600' bottom={40}>
                     <Text color='$white' size='sm'>{`+ 관심 ${data.favoriteCount.toLocaleString('ko-KO')}`}</Text>
                 </Center>
             </Pressable>

--- a/components/Detail/DetailHeader.tsx
+++ b/components/Detail/DetailHeader.tsx
@@ -1,0 +1,54 @@
+import { Text } from "@gluestack-ui/themed";
+import { HStack } from "@gluestack-ui/themed";
+import { WebtoonDetail } from "../../types";
+import { useQuery } from "@tanstack/react-query";
+import { VStack } from "@gluestack-ui/themed";
+import { Box } from "@gluestack-ui/themed";
+import { Image } from "expo-image";
+import convertUrl from "../../utils/convertUrl";
+import { Dimensions } from "react-native";
+import DetailInfo from "./DetailInfo";
+
+interface DetailHeaderProp {
+    titleId: number;
+}
+
+const width = Dimensions.get('window').width;
+
+const fetchArticleList = async(titleId: number) => {
+    const res = await fetch(`https://comic.naver.com/api/article/list/info?titleId=${titleId}`);
+    return res.json();
+}
+
+export default function DetailHeader({titleId}: DetailHeaderProp) {
+    const { data } = useQuery<WebtoonDetail> ({ // Webtoon 배열
+        queryKey: ['fetchArticleList', titleId], // 쿼리 식별하는 고유한 키
+        queryFn: () => fetchArticleList(titleId), // 쿼리를 실행하는 비동기 함수
+    });
+
+    // console.log(data?.titleName);
+
+    if(!data) {
+        return;
+    }
+
+
+    return (
+    <VStack w='$full'>
+        <Box position='absolute' bg='$blueGray500' w='$full' h={width / 2}></Box>
+        <Image 
+            contentFit='contain'
+            source={{uri: convertUrl(data.thumbnailUrl)}} // onError={(error) => console.log(error)}
+            style={{ width: width, height: width }}
+        ></Image>
+        <VStack px={15} py={10} gap={4}>
+            <Text color='$backgroundLight100' size='xl'>{data.gfpAdCustomParam.titleName}</Text>
+            <HStack>
+                <Text color='$backgroundLight100' size='sm'>{data.gfpAdCustomParam.displayAuthor}</Text>
+                <Text color='$secondary400' size='sm'>{`ㆍ${data.publishDescription}`}</Text>
+            </HStack>
+            <DetailInfo synopsis={data.synopsis} />
+        </VStack>
+    </VStack>
+    )
+}

--- a/components/Detail/DetailInfo.tsx
+++ b/components/Detail/DetailInfo.tsx
@@ -1,0 +1,32 @@
+import { HStack, Text } from "@gluestack-ui/themed";
+import { VStack } from "@gluestack-ui/themed";
+import { useState } from "react";
+import { Dimensions, Pressable } from "react-native";
+import Icon from 'react-native-vector-icons/Ionicons';
+
+interface DetailInfoProps {
+    synopsis: string;
+}
+
+const width = Dimensions.get('window').width;
+
+export default function DetailInfo({synopsis}: DetailInfoProps) {
+    const [isOpen, setIsOpen] =  useState(false);
+    return (
+    <VStack>
+        <HStack>
+            {isOpen ? (<Text flex={1} color='$secondary400' size='sm'>{synopsis}</Text>) : 
+                <Text flex={1} color='$secondary400' size='sm' width={width-20} isTruncated={true}>{synopsis} </Text>
+            }
+            <Pressable onPress={() => setIsOpen(!isOpen)}>
+                <Icon
+                    width={20}
+                    size={20}
+                    name={isOpen ? 'chevron-up-outline' : 'chevron-down-outline'}
+                    color='#737373'
+                ></Icon>
+            </Pressable>
+        </HStack>
+    </VStack>
+    )
+}

--- a/components/Detail/DetailInfo.tsx
+++ b/components/Detail/DetailInfo.tsx
@@ -1,26 +1,33 @@
-import { HStack, Text } from "@gluestack-ui/themed";
+import { HStack, Pressable, Text, View } from "@gluestack-ui/themed";
 import { VStack } from "@gluestack-ui/themed";
 import { useState } from "react";
-import { Dimensions, Pressable } from "react-native";
+import { Dimensions } from "react-native";
 import Icon from 'react-native-vector-icons/Ionicons';
 
 interface DetailInfoProps {
-    synopsis: string;
+    synopsis: string,
+    description: string;
 }
 
 const width = Dimensions.get('window').width;
 
-export default function DetailInfo({synopsis}: DetailInfoProps) {
-    const [isOpen, setIsOpen] =  useState(false);
-    return (
-    <VStack>
+export default function DetailInfo({synopsis, description}: DetailInfoProps) {
+    const [isOpen, setIsOpen] =  useState(false); // (isOpen=false) == 밑으로 세부사항 보인다
+    return (  
+    <VStack> 
         <HStack>
-            {isOpen ? (<Text flex={1} color='$secondary400' size='sm'>{synopsis}</Text>) : 
-                <Text flex={1} color='$secondary400' size='sm' width={width-20} isTruncated={true}>{synopsis} </Text>
+            { isOpen ? (
+            <View>
+                <Text key={'up'} color='$secondary400' size='sm' isTruncated={!isOpen} width={width-50} bg='$secondary800'>{synopsis}</Text>
+                <HStack gap={5} >
+                    <Text color='$secondary400' size='sm'>연령</Text>
+                    <Text color='$backgroundLight100' size='sm' >{`${description}`}</Text>
+                </HStack>
+            </View>
+            ) : (<Text flex={1} key={'down'} color='$secondary400' size='sm' isTruncated={!isOpen} width={width-50}>{synopsis}</Text>)
             }
             <Pressable onPress={() => setIsOpen(!isOpen)}>
                 <Icon
-                    width={20}
                     size={20}
                     name={isOpen ? 'chevron-up-outline' : 'chevron-down-outline'}
                     color='#737373'

--- a/components/Detail/DetailInfo.tsx
+++ b/components/Detail/DetailInfo.tsx
@@ -18,7 +18,7 @@ export default function DetailInfo({synopsis, description}: DetailInfoProps) {
         <HStack>
             { isOpen ? (
             <View>
-                <Text key={'up'} color='$secondary400' size='sm' isTruncated={!isOpen} width={width-50} bg='$secondary800'>{synopsis}</Text>
+                <Text key={'up'} color='$secondary400' size='sm' isTruncated={!isOpen} width={width-50} >{synopsis}</Text>
                 <HStack gap={5} >
                     <Text color='$secondary400' size='sm'>연령</Text>
                     <Text color='$backgroundLight100' size='sm' >{`${description}`}</Text>

--- a/components/Header/DetailHeader.tsx
+++ b/components/Header/DetailHeader.tsx
@@ -12,6 +12,5 @@ export default function DetailHeader() {
             <Ionicons name='chevron-back-outline' size={30} color='red'/>
         </Pressable>
     </HStack>
-    
     )
 }

--- a/components/Header/MySwiper.tsx
+++ b/components/Header/MySwiper.tsx
@@ -15,7 +15,7 @@ export default function MySwiper() {
         queryFn: fetchWebtoons, // 쿼리를 실행하는 비동기 함수
     });
 
-  console.log(data);
+  // console.log(data);
 
   return (
     <>

--- a/components/Header/MySwiper.tsx
+++ b/components/Header/MySwiper.tsx
@@ -18,10 +18,14 @@ export default function MySwiper() {
   console.log(data);
 
   return (
-    <Swiper showsButtons={false} removeClippedSubviews={true} >
-        { data ? data.webtoons.map((webtoon) => ( // 배열 내의 모든 요소 각각 호출
+    <>
+    {data && (
+    <Swiper showsButtons={false}>
+        { data.webtoons.map((webtoon) => ( // 배열 내의 모든 요소 각각 호출
         <LargeCard key={webtoon.webtoonId} webtoon={webtoon} />
-        )): []}
+        ))}
     </Swiper>
+    )}
+    </>
   );
 }

--- a/components/WeekDay/WeekDayCard.tsx
+++ b/components/WeekDay/WeekDayCard.tsx
@@ -1,5 +1,5 @@
 import { Center, HStack, VStack } from "@gluestack-ui/themed";
-import { DetailScreensParams, ScreensParams, WeekDayWebtoon } from "../../types";
+import { DetailScreensParams, WeekDayWebtoon } from "../../types";
 import { Image } from "expo-image";
 import convertUrl from "../../utils/convertUrl";
 import { Dimensions, Pressable } from "react-native";

--- a/components/WeekDay/WeekDayCard.tsx
+++ b/components/WeekDay/WeekDayCard.tsx
@@ -1,10 +1,11 @@
 import { Center, HStack, VStack } from "@gluestack-ui/themed";
-import { WeekDayWebtoon } from "../../types";
+import { DetailScreensParams, ScreensParams, WeekDayWebtoon } from "../../types";
 import { Image } from "expo-image";
 import convertUrl from "../../utils/convertUrl";
-import { Dimensions } from "react-native";
+import { Dimensions, Pressable } from "react-native";
 import { Text } from "@gluestack-ui/themed";
 import Icon from 'react-native-vector-icons/Ionicons';
+import { NavigationProp, useNavigation } from "@react-navigation/native";
 
 interface WeekDayCardProps {
     webtoon: WeekDayWebtoon;
@@ -12,47 +13,51 @@ interface WeekDayCardProps {
 
 const width = Dimensions.get('window').width;
 
+
 export default function WeekDayCard({ webtoon }: WeekDayCardProps) {
+  const navigation = useNavigation<NavigationProp<DetailScreensParams>>();
+
   return (
-    <VStack w={width / 3.2} gap={2} >
-      <Image 
-        transition={500}
-        source={{uri: convertUrl(webtoon.thumbnailUrl)}} // onError={(error) => console.log(error)}
-        style={{ width: '100%', height: (width / 3) * 1.3, borderRadius: 3}} >
-      </Image>
-      <VStack position='absolute' w={40} h={40} p={4} gap={1}>
-        {webtoon.new && (
-          <Center w={20} h={20} bg='$green500' borderRadius='$full'>
-            <Text size='2xs' bold={true} color='$black'>신작</Text>
-          </Center>
-        )}
-        {webtoon.bm && (
-          <Center w={20} h={20}  borderRadius='$full' pl={0.2} paddingTop={0.1} style={{backgroundColor: 'rgba(0,0,0,0.7)' }} >
-            <Icon size={20} name='timer-outline' color='#22c55e'></Icon>
-          </Center>
-        )}
-        {webtoon.adult && (
-          <Center w={20} h={20} >
-            <Icon size={20} name='shield' color='#fb923c'></Icon>
-            <Icon size={9} name='person' color='white' position='absolute' paddingBottom={1}></Icon>
-          </Center>
-        )}
-      </VStack>
-      <VStack p={2} paddingLeft={2} gap={-3}>
-        <Text size='xs' color='$backgroundLight100' bold={true} isTruncated={true}>{webtoon.titleName}</Text>
-        <HStack maxWidth={(width / 3.2) - 35} alignItems='center' gap={2}>
-            <Text size='2xs' color='gray' isTruncated={true}>
-              {webtoon.author}
-            </Text>
-            <HStack alignItems='center' gap={1}>
-              <Icon size={8} name='star' color='gray'></Icon>
-              <Text w={23} size='2xs' color='gray'>
-                {webtoon.starScore.toFixed(2)}
+    <Pressable onPress={() => navigation.navigate('Detail', {titleId: webtoon.titleId})}>
+      <VStack w={width / 3.2} gap={2} >
+        <Image 
+          transition={500}
+          source={{uri: convertUrl(webtoon.thumbnailUrl)}} // onError={(error) => console.log(error)}
+          style={{ width: '100%', height: (width / 3) * 1.3, borderRadius: 3}} >
+        </Image>
+        <VStack position='absolute' w={40} h={40} p={4} gap={1}>
+          {webtoon.new && (
+            <Center w={20} h={20} bg='$green500' borderRadius='$full'>
+              <Text size='2xs' bold={true} color='$black'>신작</Text>
+            </Center>
+          )}
+          {webtoon.bm && (
+            <Center w={20} h={20}  borderRadius='$full' pl={0.2} paddingTop={0.1} style={{backgroundColor: 'rgba(0,0,0,0.7)' }} >
+              <Icon size={20} name='timer-outline' color='#22c55e'></Icon>
+            </Center>
+          )}
+          {webtoon.adult && (
+            <Center w={20} h={20} >
+              <Icon size={20} name='shield' color='#fb923c'></Icon>
+              <Icon size={9} name='person' color='white' position='absolute' paddingBottom={1}></Icon>
+            </Center>
+          )}
+        </VStack>
+        <VStack p={2} paddingLeft={2} gap={-3}>
+          <Text size='xs' color='$backgroundLight100' bold={true} isTruncated={true}>{webtoon.titleName}</Text>
+          <HStack maxWidth={(width / 3.2) - 35} alignItems='center' gap={2}>
+              <Text size='2xs' color='gray' isTruncated={true}>
+                {webtoon.author}
               </Text>
-            </HStack>
-        </HStack>
+              <HStack alignItems='center' gap={1}>
+                <Icon size={8} name='star' color='gray'></Icon>
+                <Text w={23} size='2xs' color='gray'>
+                  {webtoon.starScore.toFixed(2)}
+                </Text>
+              </HStack>
+          </HStack>
+        </VStack>
       </VStack>
-    </VStack>
-    
+    </Pressable>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@react-navigation/stack": "^6.3.21",
         "@tanstack/react-query": "^5.18.1",
         "expo": "^50.0.8",
-        "expo-dev-client": "~3.3.9",
         "expo-image": "~1.10.6",
         "expo-status-bar": "~1.11.1",
         "expo-updates": "~0.24.11",
@@ -7991,21 +7990,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/anser": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
@@ -9721,116 +9705,6 @@
       "peerDependencies": {
         "expo": "*"
       }
-    },
-    "node_modules/expo-dev-client": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-3.3.9.tgz",
-      "integrity": "sha512-qODvuyXe8FgVJhBbwDEk/snZa5wSTNHx+poNXwA/PS4gGvOxCuG+qpeQF6K4Yf6r2+sV0OtigxPJiAyhu9I4ug==",
-      "dependencies": {
-        "expo-dev-launcher": "3.6.7",
-        "expo-dev-menu": "4.5.6",
-        "expo-dev-menu-interface": "1.7.2",
-        "expo-manifests": "~0.13.0",
-        "expo-updates-interface": "~0.15.1"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-launcher": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-3.6.7.tgz",
-      "integrity": "sha512-xn0cq2LMXv5t3n4jiAPFd9rwP22GM3zsQqAOJuWXH4b7fRzO8bayxOAt1n4RrDgkVsRzgRnxHm7kkO+Eta3Kzg==",
-      "dependencies": {
-        "ajv": "8.11.0",
-        "expo-dev-menu": "4.5.6",
-        "expo-manifests": "~0.13.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.3"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-launcher/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-dev-launcher/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-dev-launcher/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "node_modules/expo-dev-menu": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-4.5.6.tgz",
-      "integrity": "sha512-V8gOFrv8JBTy50n9mTWVPKVHMcjvrpI/w5ooZGFzjoerBlPXSauIfRmHsqmgmOr3r5oWptnC2PS3LxuSo4QZ5g==",
-      "dependencies": {
-        "expo-dev-menu-interface": "1.7.2",
-        "semver": "^7.5.3"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-menu-interface": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.7.2.tgz",
-      "integrity": "sha512-V/geSB9rW0IPTR+d7E5CcvkV0uVUCE7SMHZqE/J0/dH06Wo8AahB16fimXeh5/hTL2Qztq8CQ41xpFUBoA9TEw==",
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-menu/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-dev-menu/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/expo-dev-menu/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/expo-eas-client": {
       "version": "0.11.2",
@@ -11622,11 +11496,6 @@
         "crypt": "~0.0.1",
         "is-buffer": "~1.1.1"
       }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -15770,14 +15639,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-join": {

--- a/package.json
+++ b/package.json
@@ -18,17 +18,16 @@
     "@react-navigation/stack": "^6.3.21",
     "@tanstack/react-query": "^5.18.1",
     "expo": "^50.0.8",
-    "expo-dev-client": "~3.3.9",
     "expo-image": "~1.10.6",
     "expo-status-bar": "~1.11.1",
     "expo-updates": "~0.24.11",
     "react": "18.2.0",
     "react-native": "0.73.4",
     "react-native-gesture-handler": "~2.14.0",
+    "react-native-pager-view": "6.2.3",
     "react-native-svg": "14.1.0",
     "react-native-swiper": "^1.6.0",
-    "react-native-tab-view": "^3.5.2",
-    "react-native-pager-view": "6.2.3"
+    "react-native-tab-view": "^3.5.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/screens/DetailScreen.tsx
+++ b/screens/DetailScreen.tsx
@@ -1,0 +1,21 @@
+import  React  from 'react'
+import { VStack} from "@gluestack-ui/themed"
+import { RouteProp, useRoute } from '@react-navigation/native';
+import { DetailScreensParams } from '../types';
+import DetailHeader from '../components/Detail/DetailHeader';
+
+
+type DetailScreenRouteProp = RouteProp<DetailScreensParams, 'Detail'>;
+
+export default function DetailScreen() {
+    const route = useRoute<DetailScreenRouteProp>(); // 제네릭으로 타입 지정해야 함
+    const titleId = route.params.titleId;
+
+    return ( 
+
+    <VStack bg='$backgroundDark950' w='$full' h='$full'>
+      <DetailHeader titleId={titleId} />
+    </VStack>
+  );
+}
+

--- a/screens/WebtoonScreen.tsx
+++ b/screens/WebtoonScreen.tsx
@@ -7,9 +7,10 @@ import { useState } from "react";
 import { DayArray } from "../constants";
 import WeekDayList from "../components/WeekDay/WeekDayList";
 
+
 export default function WebtoonScreen() {   
     const [index, setIndex] = useState(0);
-    
+
     const navigation = useNavigation<NavigationProp<ScreensParams>>();
     return (
     <VStack w='$full' h='$full' bg='$backgroundDark950'>
@@ -20,7 +21,9 @@ export default function WebtoonScreen() {
         <TabView
             navigationState={{ index, routes: DayArray }}
             renderScene={(route) => {
-                return <WeekDayList type={route.route.key} />;
+                return (
+                    <WeekDayList type={route.route.key} /> 
+                );
             }}
             onIndexChange={setIndex}
             renderTabBar= {(props) => <TabBar {...props} 

--- a/types.ts
+++ b/types.ts
@@ -16,7 +16,12 @@ export type CounterScreenParams = {
 export type ScreensParams = {
     Main: undefined,
     Search: undefined,
-    Detail: {webtoon: Webtoon}
+    Detail: {webtoon?: Webtoon}
+};
+
+export type DetailScreensParams = {
+    Main: undefined,
+    Detail: {titleId: number}
 };
 
 export type TabScreenParams = {
@@ -92,4 +97,97 @@ export interface WeekDayWebtoon {
     bestChallengeLevelUp: boolean,
     finish: boolean,
     new: boolean
+}
+
+export interface Author {
+    artistId: number,
+    name: string,
+    artistTypeList: string[],
+    profileBadge: string,
+    profileImageUrl: string,
+    profilePageUrl: string,
+    postDescription: string
+}
+
+export interface Tag {
+    id: number,
+    tagName: string,
+    urlPath: string,
+    curationType: string
+}
+
+export interface WebtoonDetail {
+    titleId: number,
+    thumbnailUrl: string,
+    posterThumbnailUrl: string,
+    sharedThumbnailUrl: string,
+    titleName: string,
+    contentsNo: number,
+    webtoonLevelCode: string,
+    rest: boolean,
+    finished: boolean,
+    dailyPass: boolean,
+    publishDayOfWeekList: string[],
+    chargeBestChallenge: boolean,
+    communityArtists: Author[],
+    synopsis: string,
+    favorite: boolean,
+    favoriteCount: number,
+    age: {
+        type: string,
+        description: string;
+    },
+    publishDescription: string,
+    curationTagList: Tag[],
+    thumbnailBadgeList: [],
+    adBannerList: [],
+    firstArticle: {
+        no: number,
+        subtitle: string,
+        charge: boolean
+    },
+    gfpAdCustomParam: {
+        titleId: number,
+        webtoonLevelCode: string,
+        titleName: string,
+        displayAuthor: string,
+        cpid: string,
+        cpName: string,
+        genreTypes: string[],
+        rankGenreTypes: string[],
+        tags: string[],
+        weekdays: string[],
+        finishedYn: string,
+        adultYn: string,
+        dailyPlusYn: string,
+        dailyFreeYn: string
+    },
+    new: boolean
+}
+
+export interface ArticleList {
+    no: number,
+    thumbnailUrl: string,
+    subtitle: string,
+    starScore: number,
+    bgm: boolean,
+    up: boolean,
+    charge: boolean,
+    serviceDateDescription: string,
+    volumeNo: number,
+    hasReadLog: boolean,
+    recentlyReadLog: boolean,
+    thumbnailClock: boolean,
+    thumbnailLock: boolean
+}
+
+export interface Article {
+    titleId: number,
+    webtoonLevelCode: string,
+    totalCount: number,
+    contentsNo: number,
+    finished: boolean,
+    dailyPass: boolean,
+    chargeBestChallenge: boolean,
+    articleList: ArticleList[]
 }


### PR DESCRIPTION
요일별 탭에 있는 각각의 웹툰을 눌렀을 때 각 웹툰의 상세화면으로 이동하는 화면을 구현합니다.

https://github.com/18hailey/myApp/assets/112684536/79357cc4-4deb-4da4-9004-ea4d2313800c

+연령 정보, 관심 수 표시
(관심 수의 경우 네이버웹툰처럼 로그인 먼저 한 후 접근할 수 있도록 alert 창으로 연결했습니다. )